### PR TITLE
Fix shape bug - convert all loaded images to RGB

### DIFF
--- a/loaders/motif_dataset.py
+++ b/loaders/motif_dataset.py
@@ -248,6 +248,11 @@ class ImageLoader:
 
     def __load_image(self, index):
         image = Image.open(self.__paths[index])
+        
+        # Make sure the image is RGB, because some files are loaded as CMYK
+        if image.mode == 'CMYK':
+            image = image.convert('RGB')
+        
         return image, 0
 
     @staticmethod


### PR DESCRIPTION
Some images are loaded as CMYK for some reason, making the code break when it adds the motif (with shape (512, 512, 3) ) to the image (with shape (512, 512, 4) ).
Making sure the loaded images are always RGB, fixes this problem.